### PR TITLE
Fix: Rename namespace after move from @localheinz to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE.md file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/playground
+ * @see https://github.com/ergebnis/playground
  */
 
 use Ergebnis\License;
@@ -21,7 +21,7 @@ $license = License\Type\MIT::markdown(
         new \DateTimeZone('UTC')
     ),
     License\Holder::fromString('Andreas Möller'),
-    License\Url::fromString('https://github.com/localheinz/playground')
+    License\Url::fromString('https://github.com/ergebnis/playground')
 );
 
 $license->save();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1640fd1...master`][1640fd1...master].
 
-[1640fd1...master]: https://github.com/localheinz/playground/compare/1640fd1...master
+[1640fd1...master]: https://github.com/ergebnis/playground/compare/1640fd1...master

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # playground
 
-[![Integrate](https://github.com/localheinz/playground/workflows/Integrate/badge.svg?branch=main)](https://github.com/localheinz/playground/actions)
-[![Prune](https://github.com/localheinz/playground/workflows/Prune/badge.svg?branch=main)](https://github.com/localheinz/playground/actions)
-[![Release](https://github.com/localheinz/playground/workflows/Release/badge.svg?branch=main)](https://github.com/localheinz/playground/actions)
-[![Renew](https://github.com/localheinz/playground/workflows/Renew/badge.svg?branch=main)](https://github.com/localheinz/playground/actions)
+[![Integrate](https://github.com/ergebnis/playground/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/playground/actions)
+[![Prune](https://github.com/ergebnis/playground/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/playground/actions)
+[![Release](https://github.com/ergebnis/playground/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/playground/actions)
+[![Renew](https://github.com/ergebnis/playground/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/playground/actions)
 
-[![Code Coverage](https://codecov.io/gh/localheinz/playground/branch/main/graph/badge.svg)](https://codecov.io/gh/localheinz/playground)
-[![Type Coverage](https://shepherd.dev/github/localheinz/playground/coverage.svg)](https://shepherd.dev/github/localheinz/playground)
+[![Code Coverage](https://codecov.io/gh/ergebnis/playground/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/playground)
+[![Type Coverage](https://shepherd.dev/github/ergebnis/playground/coverage.svg)](https://shepherd.dev/github/ergebnis/playground)
 
-[![Latest Stable Version](https://poser.pugx.org/localheinz/playground/v/stable)](https://packagist.org/packages/localheinz/playground)
-[![Total Downloads](https://poser.pugx.org/localheinz/playground/downloads)](https://packagist.org/packages/localheinz/playground)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/playground/v/stable)](https://packagist.org/packages/ergebnis/playground)
+[![Total Downloads](https://poser.pugx.org/ergebnis/playground/downloads)](https://packagist.org/packages/ergebnis/playground)
 
 ## Installation
 
@@ -18,7 +18,7 @@
 Run
 
 ```sh
-$ composer require localheinz/playground
+$ composer require ergebnis/playground
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "localheinz/playground",
+  "name": "ergebnis/playground",
   "type": "library",
   "description": "Provides a GitHub repository template for a PHP library.",
-  "homepage": "https://github.com/localheinz/playground",
+  "homepage": "https://github.com/ergebnis/playground",
   "license": "MIT",
   "authors": [
     {
@@ -40,16 +40,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Playground\\": "src/"
+      "Ergebnis\\Playground\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Playground\\Test\\": "test/"
+      "Ergebnis\\Playground\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/playground/issues",
-    "source": "https://github.com/localheinz/playground"
+    "issues": "https://github.com/ergebnis/playground/issues",
+    "source": "https://github.com/ergebnis/playground"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "008b4095bdd852e4a7aea2758c4e527d",
+    "content-hash": "f9c11cf6d7770e747c9d2b605359b178",
     "packages": [
         {
             "name": "composer/semver",

--- a/src/Example.php
+++ b/src/Example.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE.md file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/playground
+ * @see https://github.com/ergebnis/playground
  */
 
-namespace Localheinz\Playground;
+namespace Ergebnis\Playground;
 
 final class Example
 {

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE.md file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/playground
+ * @see https://github.com/ergebnis/playground
  */
 
-namespace Localheinz\Playground\Test\AutoReview;
+namespace Ergebnis\Playground\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\Playground\\',
-            'Localheinz\\Playground\\Test\\Unit\\'
+            'Ergebnis\\Playground\\',
+            'Ergebnis\\Playground\\Test\\Unit\\'
         );
     }
 }

--- a/test/Unit/ExampleTest.php
+++ b/test/Unit/ExampleTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE.md file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/playground
+ * @see https://github.com/ergebnis/playground
  */
 
-namespace Localheinz\Playground\Test\Unit;
+namespace Ergebnis\Playground\Test\Unit;
 
+use Ergebnis\Playground\Example;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Playground\Example;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Playground\Example
+ * @covers \Ergebnis\Playground\Example
  */
 final class ExampleTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace after moving from @localheinz to @ergebnis