### PR TITLE
Fix: Do not use $default-branch macro

### DIFF
--- a/.github/workflows/deployment-production-create.yaml
+++ b/.github/workflows/deployment-production-create.yaml
@@ -5,7 +5,7 @@ name: "Deployment"
 on: # yamllint disable-line rule:truthy
   push:
     branches:
-      - $default-branch # yamllint disable-line rule:quoted-strings
+      - "main"
 
 env:
   DEPLOYMENT_ENVIRONMENT: "production"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - $default-branch # yamllint disable-line rule:quoted-strings
+      - "main"
 
 env:
   MIN_COVERED_MSI: 100


### PR DESCRIPTION
This PR

* [x] stops using the `$default-branch` macro

🤷‍♂️ Does not appear to work, at least not when followed by a comment (needed to suppress the warning related to unquoted strings).