### PR TITLE
Fix: Use `Xdebug` instead of `pcov` for collecting code coverage

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: "Install PHP with extensions"
         uses: "shivammathur/setup-php@2.16.0"
         with:
-          coverage: "pcov"
+          coverage: "xdebug"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -54,7 +54,7 @@ jobs:
         with:
           dependencies: "${{ matrix.dependencies }}"
 
-      - name: "Collect code coverage with pcov and phpunit/phpunit"
+      - name: "Collect code coverage with Xdebug and phpunit/phpunit"
         run: "vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=.build/phpunit/logs/clover.xml"
 
       - name: "Send code coverage report to Codecov.io"


### PR DESCRIPTION
This pull request

- [x] uses `Xdebug` instead of `pcov` for collecting code coverage